### PR TITLE
Specify the Go build pack when creating an Heroku app

### DIFF
--- a/Readme
+++ b/Readme
@@ -8,6 +8,11 @@ You can deploy it to heroku with the following commands:
 
 $ git clone https://github.com/kr/go-heroku-example.git
 $ cd go-heroku-example
-$ heroku create
+$ heroku create --buildpack https://github.com/kr/heroku-buildpack-go.git
 $ git push heroku master
 $ heroku open
+
+Note: If you have already done heroku create without specifying the buildpack for Go, you can add the buildpack as an environment variable using the command:
+
+$ heroku config:add BUILDPACK_URL=https://github.com/kr/heroku-buildpack-go.git
+


### PR DESCRIPTION
If you clone the Go example you still needs to specify the Go buildpack in order to successfully deploy the application on your own Heroku app.  Therefore I have updated the heroku create command with a buildpack parameter and also included the heroku command to add a buildpack config var if heroku create is used without the buildback option.
