### PR TITLE
Fix version format

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -1,5 +1,5 @@
 {
 	"ImportPath": "github.com/kr/go-heroku-example",
-	"GoVersion": "go version go1.1.2 darwin/amd64",
+	"GoVersion": "go1.2",
 	"Deps": []
 }


### PR DESCRIPTION
Spaced version format causes errors with current build pack, update to the latest and greatest.

Fixes kr/heroku-buildpack-go#35
